### PR TITLE
Update StudioCMS Deps and disable devapps in templates by default

### DIFF
--- a/studiocms/blog/astro.config.mjs
+++ b/studiocms/blog/astro.config.mjs
@@ -1,6 +1,6 @@
 import db from '@astrojs/db';
 import node from '@astrojs/node';
-import devApps from '@studiocms/devapps';
+// import devApps from '@studiocms/devapps'; // - disabled due to production bug
 import { defineConfig } from 'astro/config';
 import studioCMS from 'studiocms';
 
@@ -12,5 +12,5 @@ export default defineConfig({
 	security: {
 		checkOrigin: false, // This depends on your hosting provider
 	},
-	integrations: [db(), studioCMS(), devApps()],
+	integrations: [db(), studioCMS()],
 });

--- a/studiocms/blog/package.json
+++ b/studiocms/blog/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "@astrojs/db": "^0.14.6",
     "@astrojs/node": "^9.1.1",
-    "@studiocms/blog": "^0.1.0-beta.9",
-    "@studiocms/devapps": "^0.1.0-beta.9",
+    "@studiocms/blog": "^0.1.0-beta.10",
+    "@studiocms/devapps": "^0.1.0-beta.10",
     "astro": "^5.3.1",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.9"
+    "studiocms": "^0.1.0-beta.10"
   }
 }

--- a/studiocms/headless/astro.config.mjs
+++ b/studiocms/headless/astro.config.mjs
@@ -1,6 +1,6 @@
 import db from '@astrojs/db';
 import node from '@astrojs/node';
-import devApps from '@studiocms/devapps';
+// import devApps from '@studiocms/devapps'; // - disabled due to production bug
 import { defineConfig } from 'astro/config';
 import studioCMS from 'studiocms';
 
@@ -12,5 +12,5 @@ export default defineConfig({
 	security: {
 		checkOrigin: false, // This depends on your hosting provider
 	},
-	integrations: [db(), studioCMS(), devApps()],
+	integrations: [db(), studioCMS()],
 });

--- a/studiocms/headless/package.json
+++ b/studiocms/headless/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "@astrojs/db": "^0.14.6",
     "@astrojs/node": "^9.1.1",
-    "@studiocms/devapps": "^0.1.0-beta.9",
+    "@studiocms/devapps": "^0.1.0-beta.10",
     "astro": "^5.3.1",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.9"
+    "studiocms": "^0.1.0-beta.10"
   }
 }


### PR DESCRIPTION
This pull request includes changes to disable the `devApps` integration due to a production bug and updates the package versions for `@studiocms` dependencies. The changes affect the configuration and package files for both the `blog` and `headless` projects.

Disabling `devApps` integration:

* [`studiocms/blog/astro.config.mjs`](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L3-R3): Commented out the import for `devApps` and removed it from the `integrations` array. [[1]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L3-R3) [[2]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L15-R15)
* [`studiocms/headless/astro.config.mjs`](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L3-R3): Commented out the import for `devApps` and removed it from the `integrations` array. [[1]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L3-R3) [[2]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L15-R15)

Updating package versions:

* [`studiocms/blog/package.json`](diffhunk://#diff-55eb3c68db4bd2053292b557ac8568adb771b1eeb97f4970ad79bf0c91d1c8faL20-R24): Updated the versions of `@studiocms/blog`, `@studiocms/devapps`, and `studiocms` to `^0.1.0-beta.10`.
* [`studiocms/headless/package.json`](diffhunk://#diff-b0925c44fc8bffccd7d110779e983d1c5bbcf82cde597f312a09dc20eeca7673L20-R23): Updated the versions of `@studiocms/devapps` and `studiocms` to `^0.1.0-beta.10`.