### PR TITLE
Update studiocms deps

### DIFF
--- a/studiocms/blog/package.json
+++ b/studiocms/blog/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "@astrojs/db": "^0.14.6",
     "@astrojs/node": "^9.1.1",
-    "@studiocms/blog": "^0.1.0-beta.10",
-    "@studiocms/devapps": "^0.1.0-beta.10",
+    "@studiocms/blog": "^0.1.0-beta.11",
+    "@studiocms/devapps": "^0.1.0-beta.11",
     "astro": "^5.3.1",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.10"
+    "studiocms": "^0.1.0-beta.11"
   }
 }

--- a/studiocms/headless/package.json
+++ b/studiocms/headless/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "@astrojs/db": "^0.14.6",
     "@astrojs/node": "^9.1.1",
-    "@studiocms/devapps": "^0.1.0-beta.10",
+    "@studiocms/devapps": "^0.1.0-beta.11",
     "astro": "^5.3.1",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.10"
+    "studiocms": "^0.1.0-beta.11"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the dependencies in the `package.json` files for the `studiocms/blog` and `studiocms/headless` packages. The changes primarily involve updating the version numbers of several `@studiocms` dependencies.

Dependency updates:

* [`studiocms/blog/package.json`](diffhunk://#diff-55eb3c68db4bd2053292b557ac8568adb771b1eeb97f4970ad79bf0c91d1c8faL20-R24): Updated `@studiocms/blog`, `@studiocms/devapps`, and `studiocms` dependencies to version `0.1.0-beta.11`.
* [`studiocms/headless/package.json`](diffhunk://#diff-b0925c44fc8bffccd7d110779e983d1c5bbcf82cde597f312a09dc20eeca7673L20-R23): Updated `@studiocms/devapps` and `studiocms` dependencies to version `0.1.0-beta.11`.
