### PR TITLE
Update template versions to match minimum versions from monorepo

### DIFF
--- a/studiocms/blog/package.json
+++ b/studiocms/blog/package.json
@@ -15,11 +15,11 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@astrojs/db": "^0.14.6",
-    "@astrojs/node": "^9.1.1",
+    "@astrojs/db": "^0.14.7",
+    "@astrojs/node": "^9.1.2",
     "@studiocms/blog": "^0.1.0-beta.11",
     "@studiocms/devapps": "^0.1.0-beta.11",
-    "astro": "^5.3.1",
+    "astro": "^5.4.0",
     "sharp": "^0.33.5",
     "studiocms": "^0.1.0-beta.11"
   }

--- a/studiocms/headless/package.json
+++ b/studiocms/headless/package.json
@@ -15,10 +15,10 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@astrojs/db": "^0.14.6",
-    "@astrojs/node": "^9.1.1",
+    "@astrojs/db": "^0.14.7",
+    "@astrojs/node": "^9.1.2",
     "@studiocms/devapps": "^0.1.0-beta.11",
-    "astro": "^5.3.1",
+    "astro": "^5.4.0",
     "sharp": "^0.33.5",
     "studiocms": "^0.1.0-beta.11"
   }


### PR DESCRIPTION
This pull request includes dependency updates in the `studiocms/blog` and `studiocms/headless` packages. The most important changes are the version bumps for several dependencies.

Dependency updates:

* [`studiocms/blog/package.json`](diffhunk://#diff-55eb3c68db4bd2053292b557ac8568adb771b1eeb97f4970ad79bf0c91d1c8faL18-R22): Updated `@astrojs/db` to version `0.14.7`, `@astrojs/node` to version `9.1.2`, and `astro` to version `5.4.0`.
* [`studiocms/headless/package.json`](diffhunk://#diff-b0925c44fc8bffccd7d110779e983d1c5bbcf82cde597f312a09dc20eeca7673L18-R21): Updated `@astrojs/db` to version `0.14.7`, `@astrojs/node` to version `9.1.2`, and `astro` to version `5.4.0`.
