### PR TITLE
Add gitignore files to templates

### DIFF
--- a/studiocms/blog/.gitignore
+++ b/studiocms/blog/.gitignore
@@ -1,0 +1,24 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/studiocms/blog/.gitignore
+++ b/studiocms/blog/.gitignore
@@ -1,5 +1,7 @@
 # build output
 dist/
+.output/
+.vercel/
 # generated types
 .astro/
 

--- a/studiocms/headless/.gitignore
+++ b/studiocms/headless/.gitignore
@@ -1,0 +1,24 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/studiocms/headless/.gitignore
+++ b/studiocms/headless/.gitignore
@@ -1,5 +1,7 @@
 # build output
 dist/
+.output/
+.vercel/
 # generated types
 .astro/
 


### PR DESCRIPTION
This pull request includes updates to the `.gitignore` files in the `studiocms/blog` and `studiocms/headless` directories. The changes primarily focus on excluding various types of files and directories that should not be tracked by version control.

The most important changes include:

* Exclusion of build output directories (`dist/`).
* Ignoring generated types directories (`.astro/`).
* Ignoring dependencies directories (`node_modules/`).
* Exclusion of log files (`npm-debug.log*`, `yarn-debug.log*`, `yarn-error.log*`, `pnpm-debug.log*`).
* Ignoring environment variable files (`.env`, `.env.production`).
* Exclusion of macOS-specific files (`.DS_Store`).
* Ignoring JetBrains IDE setting folders (`.idea/`).
