### PR TITLE
Update studiocms deps

### DIFF
--- a/studiocms/blog/astro.config.mjs
+++ b/studiocms/blog/astro.config.mjs
@@ -1,6 +1,6 @@
 import db from '@astrojs/db';
 import node from '@astrojs/node';
-// import devApps from '@studiocms/devapps'; // - disabled due to production bug
+import devApps from '@studiocms/devapps';
 import { defineConfig } from 'astro/config';
 import studioCMS from 'studiocms';
 
@@ -12,5 +12,5 @@ export default defineConfig({
 	security: {
 		checkOrigin: false, // This depends on your hosting provider
 	},
-	integrations: [db(), studioCMS()],
+	integrations: [db(), studioCMS(), devApps()],
 });

--- a/studiocms/blog/package.json
+++ b/studiocms/blog/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "@astrojs/db": "^0.14.7",
     "@astrojs/node": "^9.1.2",
-    "@studiocms/blog": "^0.1.0-beta.11",
-    "@studiocms/devapps": "^0.1.0-beta.11",
+    "@studiocms/blog": "^0.1.0-beta.12",
+    "@studiocms/devapps": "^0.1.0-beta.12",
     "astro": "^5.4.0",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.11"
+    "studiocms": "^0.1.0-beta.12"
   }
 }

--- a/studiocms/headless/astro.config.mjs
+++ b/studiocms/headless/astro.config.mjs
@@ -1,6 +1,6 @@
 import db from '@astrojs/db';
 import node from '@astrojs/node';
-// import devApps from '@studiocms/devapps'; // - disabled due to production bug
+import devApps from '@studiocms/devapps'; // - disabled due to production bug
 import { defineConfig } from 'astro/config';
 import studioCMS from 'studiocms';
 
@@ -12,5 +12,5 @@ export default defineConfig({
 	security: {
 		checkOrigin: false, // This depends on your hosting provider
 	},
-	integrations: [db(), studioCMS()],
+	integrations: [db(), studioCMS(), devApps()],
 });

--- a/studiocms/headless/package.json
+++ b/studiocms/headless/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "@astrojs/db": "^0.14.7",
     "@astrojs/node": "^9.1.2",
-    "@studiocms/devapps": "^0.1.0-beta.11",
+    "@studiocms/devapps": "^0.1.0-beta.12",
     "astro": "^5.4.0",
     "sharp": "^0.33.5",
-    "studiocms": "^0.1.0-beta.11"
+    "studiocms": "^0.1.0-beta.12"
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `astro.config.mjs` and `package.json` files for both the `blog` and `headless` projects within the `studiocms` directory. The changes primarily involve re-enabling the `devApps` integration and updating dependency versions.

Changes to `astro.config.mjs`:

* Re-enabled the `devApps` import and added it to the `integrations` array in both `studiocms/blog/astro.config.mjs` and `studiocms/headless/astro.config.mjs`. [[1]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L3-R3) [[2]](diffhunk://#diff-62d469a91209b77db3ba2c670af945f065b662db594bb9b7f6a1116c52f84b76L15-R15) [[3]](diffhunk://#diff-90418fcdc3bc6de2a3d68f0fe13d07c90281f98b2e3e4ec355766c90fd6bb5d3L3-R3) [[4]](diffhunk://#diff-90418fcdc3bc6de2a3d68f0fe13d07c90281f98b2e3e4ec355766c90fd6bb5d3L15-R15)

Changes to `package.json`:

* Updated the versions of `@studiocms/blog`, `@studiocms/devapps`, and `studiocms` dependencies from `0.1.0-beta.11` to `0.1.0-beta.12` in both `studiocms/blog/package.json` and `studiocms/headless/package.json`. [[1]](diffhunk://#diff-55eb3c68db4bd2053292b557ac8568adb771b1eeb97f4970ad79bf0c91d1c8faL20-R24) [[2]](diffhunk://#diff-b0925c44fc8bffccd7d110779e983d1c5bbcf82cde597f312a09dc20eeca7673L20-R23)