### PR TITLE
update dependencies to version 0.1.0-beta.26

### DIFF
--- a/studiocms/blog/package.json
+++ b/studiocms/blog/package.json
@@ -18,11 +18,11 @@
 	"dependencies": {
 		"@astrojs/db": "^0.17.1",
 		"@astrojs/node": "^9.4.3",
-		"@studiocms/blog": "^0.1.0-beta.25",
-		"@studiocms/devapps": "^0.1.0-beta.25",
-		"@studiocms/md": "^0.1.0-beta.25",
-		"astro": "^5.13.3",
+		"@studiocms/blog": "^0.1.0-beta.26",
+		"@studiocms/devapps": "^0.1.0-beta.26",
+		"@studiocms/md": "^0.1.0-beta.26",
+		"astro": "^5.13.5",
 		"sharp": "^0.34.3",
-		"studiocms": "^0.1.0-beta.25"
+		"studiocms": "^0.1.0-beta.26"
 	}
 }

--- a/studiocms/headless/package.json
+++ b/studiocms/headless/package.json
@@ -18,12 +18,12 @@
 	"dependencies": {
 		"@astrojs/db": "^0.17.1",
 		"@astrojs/node": "^9.4.3",
-		"@studiocms/devapps": "^0.1.0-beta.25",
-		"@studiocms/github": "^0.1.0-beta.25",
-		"@studiocms/md": "^0.1.0-beta.25",
-		"@studiocms/html": "^0.1.0-beta.25",
-		"astro": "^5.13.3",
+		"@studiocms/devapps": "^0.1.0-beta.26",
+		"@studiocms/github": "^0.1.0-beta.26",
+		"@studiocms/md": "^0.1.0-beta.26",
+		"@studiocms/html": "^0.1.0-beta.26",
+		"astro": "^5.13.5",
 		"sharp": "^0.34.3",
-		"studiocms": "^0.1.0-beta.25"
+		"studiocms": "^0.1.0-beta.26"
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies across StudioCMS Blog and Headless to 0.1.0-beta.26 (including core and related @studiocms packages such as blog, devapps, md, html, and github).
  * Upgraded Astro to 5.13.5 for both Blog and Headless projects.
  * No changes to exported/public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->